### PR TITLE
fix: allow mp4 video as card thumbnail (#32)

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -81,11 +81,11 @@ collections:
 
       - name: thumbnail
         label: Card Thumbnail
-        widget: image
+        widget: file
         required: false
         media_folder: ''
         public_folder: ''
-        hint: 'Override the card thumbnail. Leave blank to use the first project image.'
+        hint: 'Override the card thumbnail. Leave blank to use the first project image. Accepts images or mp4 video.'
 
       - name: media
         label: Media


### PR DESCRIPTION
Changes thumbnail CMS field from `widget: image` to `widget: file` so mp4 videos can be selected. Build.js already renders `<video>` for `.mp4` thumbnails — no backend changes needed.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)